### PR TITLE
added `ExpressionAttributeNames` to scan params to handle DynamoDB reserved words

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 keys.mine.js
+.idea/

--- a/lib/dynamodb-store.js
+++ b/lib/dynamodb-store.js
@@ -345,6 +345,8 @@ module.exports = function(options) {
 
               // next page or end, depending on condition
               next();
+            } else {
+              next(err);
             }
           });
         // all pages fetched, prepare and return result

--- a/lib/dynamodb-store.js
+++ b/lib/dynamodb-store.js
@@ -253,6 +253,8 @@ module.exports = function(options) {
       // Required by DynamoDB for multy property scan filter
       var filterExpression = [];
       var expressionAttributeValues = {};
+      var expressionAttributeNames = {};
+      var attrNamePrefix = "#attr_";
 
       if(!q.all$) {
         if(_.keys(q).length === 1 && q.id) {
@@ -265,7 +267,8 @@ module.exports = function(options) {
           // filters are joined with AND operator
           for (var param in q) {
              if(_.has(q, param) && !param.match(/\$$/)) {
-                filterExpression.push("(" + param + "=:" + param + ")");
+                expressionAttributeNames[attrNamePrefix + param] = param;
+                filterExpression.push("(" + attrNamePrefix + param + "=:" + param + ")");
                 switch (typeof q[param]) {
                   case "number":
                     expressionAttributeValues[":" + param] = {

--- a/lib/dynamodb-store.js
+++ b/lib/dynamodb-store.js
@@ -324,6 +324,7 @@ module.exports = function(options) {
         // repeat getPage function until there are pages to fetch
         async.until(function (){return (morePages === false);}, function getPage(next){
           connection.scan(params, function(err, res) {
+            if (err) return next(err);
             if (!error(args, err, cb)) {
               var items = res.Items.map(unmarshalItem);
               items.forEach(function(item) {
@@ -348,6 +349,7 @@ module.exports = function(options) {
           });
         // all pages fetched, prepare and return result
         }, function end(err){
+          if (err) return cb(err);
             // we have all the totalItems now
             seneca.log(args.tag$, 'list/scan', list);
             cb(null, list);

--- a/lib/dynamodb-store.js
+++ b/lib/dynamodb-store.js
@@ -323,7 +323,7 @@ module.exports = function(options) {
         var list = [];
         // repeat getPage function until there are pages to fetch
         async.until(function (){return (morePages === false);}, function getPage(next){
-          connection.scan(params, function(err, res) {
+          connection.query(params, function(err, res) {
             if (err) return next(err);
             if (!error(args, err, cb)) {
               var items = res.Items.map(unmarshalItem);

--- a/lib/dynamodb-store.js
+++ b/lib/dynamodb-store.js
@@ -314,6 +314,10 @@ module.exports = function(options) {
         if (!_.isEmpty(expressionAttributeValues)) {
           params.ExpressionAttributeValues = expressionAttributeValues;
         }
+        // Add attribute names if present
+        if (!_.isEmpty(expressionAttributeNames)) {
+          params.ExpressionAttributeNames = expressionAttributeNames;
+        }
         // dealing with DynamoDB pagination
         var morePages = true;
         var list = [];


### PR DESCRIPTION
Now you can use DynamoDB reserved words (such as `type` or `resource`, for example) as your entity attributes!